### PR TITLE
Expose base url and update default fetch policy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ const [{data, loading, error}] = useApiQuery({url: `/users/${id}`})
   - [`Api`](#api)
     - [`Constructor`](#constructor)
     - [`baseUrl`](#baseurl)
+    - [`defaultFetchPolicy`](#defaultfetchpolicy)
     - [`request(params: object, opts?: object)`](#requestparams-object-opts-object)
     - [`requestInProgress(params: object)`](#requestinprogressparams-object)
     - [`writeCachedResponse(params: object, responseBody?: Blob | object | string)`](#writecachedresponseparams-object-responsebody-blob--object--string)
@@ -243,11 +244,11 @@ Here are the possible fetch policies:
 | `cache-only`      | The request will _only_ read from the cache and never fetch from the server.<br />If the data does not exist, it will throw an `ApiCacheMissError`.                                                                                                                                                                                                                                                                |
 | `cache-and-fetch` | The request will simultaneously read from the cache and fetch from the server.<br />If the data is in the cache, the promise will resolve with the cached results. Once the fetch resolves, it will update the cache in the background and emit an event to notify listeners of the update.<br />If the data is not in the cache, the promise will resolve with the result of the fetch and then update the cache. |
 
-If you'd like to override the default `fetchPolicy` for `useApiQuery`, you can pass a `defaultFetchPolicy` prop to `<ApiProvider />`:
+If you'd like to override the default `fetchPolicy` for `useApiQuery`, you can pass a `defaultFetchPolicies` prop to `<ApiProvider />`:
 
 ```jsx
 const App = () => (
-  <ApiProvider api={api} defaultFetchPolicy='fetch-first'>
+  <ApiProvider api={api} defaultFetchPolicies={{useApiQuery: 'fetch-first'}}>
     {/* Render app */}
   </ApiProvider>
 )
@@ -667,7 +668,12 @@ import {ApiProvider} from 'fairlight'
 const api = new Api({baseUrl: 'http://your-api.com/api'})
 
 const App = () => (
-  <ApiProvider api={api} defaultFetchPolicy='cache-and-fetch'>
+  <ApiProvider
+    api={api}
+    defaultFetchPolicies={{
+      useApiQuery: 'cache-and-fetch'
+    }}
+  >
     {/* render app here */}
   </ApiProvider>
 )
@@ -679,10 +685,16 @@ const App = () => (
 
 `props`:
 
-| Field                                                                                                    | Description                                                                                     |
-| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `api: Api`                                                                                               | `Api` instance to provide to your app.                                                          |
-| `defaultFetchPolicy?: 'no-cache' \| 'cache-first' \| 'fetch-first' \| 'cache-only' \| 'cache-and-fetch'` | Sets the default `fetchPolicy` for all `useApiQuery()` requests. Defaults to `cache-and-fetch`. |
+| Field                          | Description                                                                      |
+| ------------------------------ | -------------------------------------------------------------------------------- |
+| `api: Api`                     | `Api` instance to provide to your app.                                           |
+| `defaultFetchPolicies: object` | Sets the default `fetchPolicy` to use for hooks. See below for possible options. |
+
+`defaultFetchPolicies` fields:
+
+| Field                                                                                            | Description                                                                                                     |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `useApiQuery: 'no-cache' \| 'cache-first' \| 'fetch-first' \| 'cache-only' \| 'cache-and-fetch'` | The `fetchPolicy` to use by default for the `useApiQuery` hook. Defaults to `cache-and-fetch` if not specified. |
 
 </details>
 
@@ -869,6 +881,10 @@ Constructor fields:
 #### `baseUrl`
 
 The `baseUrl` that was set via the `Api` constructor.
+
+#### `defaultFetchPolicy`
+
+The `defaultFetchPolicy` that was set via the `Api` constructor.
 
 #### `request(params: object, opts?: object)`
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ const [{data, loading, error}] = useApiQuery({url: `/users/${id}`})
   - [`RestEndpoints`](#restendpoints)
   - [`Api`](#api)
     - [`Constructor`](#constructor)
+    - [`baseUrl`](#baseurl)
     - [`request(params: object, opts?: object)`](#requestparams-object-opts-object)
     - [`requestInProgress(params: object)`](#requestinprogressparams-object)
     - [`writeCachedResponse(params: object, responseBody?: Blob | object | string)`](#writecachedresponseparams-object-responsebody-blob--object--string)
@@ -864,6 +865,10 @@ Constructor fields:
 | `parseResponseJson?(body: object): object`                                                               | When provided, all JSON response bodies will be run through this transformation function before returning the response. |
 
 </details>
+
+#### `baseUrl`
+
+The `baseUrl` that was set via the `Api` constructor.
 
 #### `request(params: object, opts?: object)`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fairlight",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cache",
     "fetch"
   ],
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -30,6 +30,10 @@ it('applies the base URL to requests', async () => {
   expect(request.url).toEqual('http://test.com/endpoint')
 })
 
+it('exposes the base url', () => {
+  expect(api.baseUrl).toEqual('http://test.com')
+})
+
 describe('defaultFetchPolicy', () => {
   it('defaults to fetch-first', () => {
     expect(new Api().defaultFetchPolicy).toEqual('fetch-first')

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -59,6 +59,10 @@ export class Api {
     )
   }
 
+  get baseUrl() {
+    return this.requestManager.baseUrl
+  }
+
   /**
    * Makes an API request
    */

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -59,6 +59,9 @@ export class Api {
     )
   }
 
+  /**
+   * Returns the `baseUrl` which was set via the constructor.
+   */
   get baseUrl() {
     return this.requestManager.baseUrl
   }

--- a/src/api/request-manager/index.tsx
+++ b/src/api/request-manager/index.tsx
@@ -7,6 +7,7 @@ import {applyHeaders, createSubscription, getParamsId} from '../lib'
 import {ApiRequestFetcher} from '../request-fetcher'
 import {
   ApiParseResponseJson,
+  ApiRequestFetchPolicy,
   ApiRequestMethod,
   ApiRequestOptions,
   ApiRequestParams,
@@ -36,6 +37,8 @@ const ERROR_EVENT = 'error'
 export class ApiRequestManager {
   baseUrl: string
 
+  defaultFetchPolicy: ApiRequestFetchPolicy
+
   private emitter = new EventEmitter()
 
   private requestFetcher: RequestFetcher
@@ -57,6 +60,10 @@ export class ApiRequestManager {
      */
     baseUrl?: string
     /**
+     * Base URL of API to prefix all requests with
+     */
+    defaultFetchPolicy?: ApiRequestFetchPolicy
+    /**
      * When provided, all API JSON request bodies will be run
      * through this transformation function before the API request
      */
@@ -69,6 +76,7 @@ export class ApiRequestManager {
     requestFetcher?: RequestFetcher
   }) {
     this.baseUrl = params.baseUrl || ''
+    this.defaultFetchPolicy = params.defaultFetchPolicy || DEFAULT_FETCH_POLICY
     this.requestFetcher = params.requestFetcher || new ApiRequestFetcher()
     this.serializeRequestJson = params.serializeRequestJson || identity
     this.parseResponseJson = params.parseResponseJson || identity
@@ -169,7 +177,7 @@ export class ApiRequestManager {
     options: ApiRequestOptions
   ): Promise<ResponseBody | null> => {
     const {method = DEFAULT_REQUEST_METHOD} = params
-    const {fetchPolicy = DEFAULT_FETCH_POLICY} = options
+    const {fetchPolicy = this.defaultFetchPolicy} = options
     try {
       let headers = new Headers(this.defaultHeaders)
 

--- a/src/react/context.tsx
+++ b/src/react/context.tsx
@@ -3,16 +3,22 @@ import React, {createContext} from 'react'
 import {Api} from '../api'
 import {ApiRequestFetchPolicy} from '../api/typings'
 
-const DEFAULT_FETCH_POLICY = 'cache-and-fetch'
+const DEFAULT_QUERY_FETCH_POLICY = 'cache-and-fetch'
 
 interface ApiContext {
   api: Api
-  defaultFetchPolicy: ApiRequestFetchPolicy
+  defaultFetchPolicies: ApiProviderDefaultFetchPolicies
+}
+
+interface ApiProviderDefaultFetchPolicies {
+  useApiQuery: ApiRequestFetchPolicy
 }
 
 export const ApiContext = createContext<ApiContext>({
   api: new Api(),
-  defaultFetchPolicy: DEFAULT_FETCH_POLICY
+  defaultFetchPolicies: {
+    useApiQuery: DEFAULT_QUERY_FETCH_POLICY
+  }
 })
 
 export interface ApiProviderProps {
@@ -25,7 +31,7 @@ export interface ApiProviderProps {
    * Sets the default `fetchPolicy` which is used by `useApiQuery`
    * if no `fetchPolicy` is provided to the hook.
    */
-  defaultFetchPolicy?: ApiRequestFetchPolicy
+  defaultFetchPolicy?: Partial<ApiRequestFetchPolicy>
 }
 
 export const ApiProvider: React.FC<ApiProviderProps> = function ApiProvider(
@@ -35,7 +41,9 @@ export const ApiProvider: React.FC<ApiProviderProps> = function ApiProvider(
     <ApiContext.Provider
       value={{
         api: props.api,
-        defaultFetchPolicy: props.defaultFetchPolicy || DEFAULT_FETCH_POLICY
+        defaultFetchPolicies: {
+          useApiQuery: props.defaultFetchPolicy || DEFAULT_QUERY_FETCH_POLICY
+        }
       }}
     >
       {props.children}

--- a/src/react/use-api-query/index.tsx
+++ b/src/react/use-api-query/index.tsx
@@ -71,7 +71,10 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
     dontReinitialize?: boolean
   } = {}
 ): [UseApiQueryData<TResponseBody>, UseApiQueryActions<TResponseBody>] {
-  const {api, defaultFetchPolicy} = useContext(ApiContext)
+  const {
+    api,
+    defaultFetchPolicies: {useApiQuery: defaultFetchPolicy}
+  } = useContext(ApiContext)
   const fetchPolicy = opts.fetchPolicy || defaultFetchPolicy
   const paramsId = params && getParamsId(params)
   const [state, dispatch] = useReducer(useApiQueryReducer, null, () => ({


### PR DESCRIPTION
* Expose `Api#baseUrl` (needed it for some UI work)
* Fix a bug where `Api#defaultFetchPolicy` was not being used
* Rename `ApiProvider#defaultFetchPolicy` prop to `defaultFetchPolicies`, which now takes an object*. This will future-proof it so that we can pass different default fetch policies for different hooks (ie. for mutations - #28)
* Bump version to `v0.4.2`