### PR TITLE
Allow functional updates in setData

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,14 +335,14 @@ friendsQueryActions.refetch()
 For example, suppose we have a query to get a user:
 
 ```tsx
-const [user] = useApiQuery(userEndpoints.findById(1))
+const [user] = useApiQuery(UserEndpoints.findById(1))
 ```
 
-Now, suppose we also have a form that updates a user. Once this succeeds, we can update the data for our above query using the response for the update request:
+Now, suppose we also have a form that updates a user. This API request happens to returns the updated user, so we can use `setData` to update our `useApiQuery` data with the most up-to-date user.
 
 ```tsx
 const api = useApi()
-const [user, userQueryActions] = useApiQuery(userEndpoints.findById(1))
+const [user, userQueryActions] = useApiQuery(UserEndpoints.findById(1))
 
 const handleSubmit = async (values) => {
   try {

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -138,8 +138,10 @@ export class Api {
    */
   readCachedResponse = <TResponseBody extends ResponseBody>(
     params: ApiRequestParams<ApiRequestMethod, TResponseBody>
-  ): TResponseBody => {
-    return this.responseBodyCache.get(getParamsId(params)) as TResponseBody
+  ): TResponseBody | null => {
+    return this.responseBodyCache.get(
+      getParamsId(params)
+    ) as TResponseBody | null
   }
 
   /**

--- a/src/react/use-api-query/actions.tsx
+++ b/src/react/use-api-query/actions.tsx
@@ -48,5 +48,5 @@ export const useApiQueryActions = {
   /**
    * The `data` should be set manually.
    */
-  setData: createStandardAction('SET_DATA')<any>()
+  setData: createStandardAction('SET_DATA')<any | ((prev: any) => any)>()
 }

--- a/src/react/use-api-query/reducer.tsx
+++ b/src/react/use-api-query/reducer.tsx
@@ -63,19 +63,14 @@ export const useApiQueryReducer: Reducer<
       }
 
       return prev
-    case getType(useApiQueryActions.setData): {
-      if (typeof action.payload === 'function') {
-        return {
-          ...prev,
-          data: action.payload(prev.data)
-        }
-      }
-
+    case getType(useApiQueryActions.setData):
       return {
         ...prev,
-        data: action.payload
+        data:
+          typeof action.payload === 'function'
+            ? action.payload(prev.data)
+            : action.payload
       }
-    }
     default:
       return prev
   }

--- a/src/react/use-api-query/reducer.tsx
+++ b/src/react/use-api-query/reducer.tsx
@@ -63,11 +63,19 @@ export const useApiQueryReducer: Reducer<
       }
 
       return prev
-    case getType(useApiQueryActions.setData):
+    case getType(useApiQueryActions.setData): {
+      if (typeof action.payload === 'function') {
+        return {
+          ...prev,
+          data: action.payload(prev.data)
+        }
+      }
+
       return {
         ...prev,
         data: action.payload
       }
+    }
     default:
       return prev
   }


### PR DESCRIPTION
## Summary of Changes
* Modify `useApiQuery#setData` to allow a function to be passed, which sets the data using a function of its previous state (similar to `react#useState`)
* Update `useApiQuery` API docs and add a section in the guide for `setData`

Resolves #32 