### PR TITLE
Success codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,8 @@ jobs:
       - run: npm run lint
       - name: Set ENV for codeclimate (pull_request)
         run: |
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/$GITHUB_HEAD_REF:refs/remotes/origin/$GITHUB_HEAD_REF
-          echo "::set-env name=GIT_BRANCH::$GITHUB_HEAD_REF"
-          echo "::set-env name=GIT_COMMIT_SHA::$(git rev-parse origin/$GITHUB_HEAD_REF)"
+          echo "::set-env name=GIT_BRANCH::${{ github.head_ref }}"
+          echo "::set-env name=GIT_COMMIT_SHA::$(git rev-parse HEAD)"
         if: github.event_name == 'pull_request'
       - name: Set ENV for codeclimate (push)
         run: |
@@ -39,7 +38,7 @@ jobs:
       - name: Code Climate Test Reporter
         uses: aktions/codeclimate-test-reporter@v1
         with:
-          codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
+          codeclimate-test-reporter-id: e603a31c2988a01bae194f33de60d6f6f17b68cc8f36e5479f987e34d2186988
   build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ const [{data, loading, error}] = useApiQuery({url: `/users/${id}`})
   - [Dependent queries](#dependent-queries)
   - [Manually updating query data](#manually-updating-query-data)
   - [Custom response body parsing](#custom-response-body-parsing)
+  - [Success response codes](#success-response-codes)
   - [Custom query string serialization](#custom-query-string-serialization)
   - [Setting default headers (ie. an auth token) for all requests](#setting-default-headers-ie-an-auth-token-for-all-requests)
   - [Error handling](#error-handling)
@@ -386,6 +387,31 @@ class TransactionEndpoints extends HttpEndpoints {
 const csv = await api.request(TransactionEndpoints.csvExport)
 
 // typeof csv === 'string'
+```
+
+### Success response codes
+
+By default, requests with response statuses in the `200`-range (200-299) will be considered successful, with anything outside of the range throwing an `ApiError`. If you'd like to customize the success statuses, you can set `successCodes`:
+
+```tsx
+class UserEndpoints extends HttpEndpoints {
+  static basePath = '/users'
+
+  static create(body) {
+    return super._post('', {
+      body,
+      successCodes: [201]
+    })
+  }
+}
+
+await api.request(
+  UserEndpoints.create({
+    firstName: 'Jane',
+    lastName: 'Doe'
+  })
+)
+// ↑ any response status other than `201` will throw `ApiError`
 ```
 
 ### Custom query string serialization
@@ -947,6 +973,7 @@ const user = await api.request({
   body: {name: 'Example User',}
   headers: {'x-user-id': '12345'},
   responseType: 'json',
+  successCodes: [200],
   extraKey: 'extra_cache_key'
 }, {
   fetchPolicy: 'no-cache',
@@ -960,14 +987,15 @@ const user = await api.request({
 
 `params` fields:
 
-| Field                                                                                                          | Description                                                                                                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url: string`                                                                                                  | URL path for the request. This will be appended to the `baseUrl` which was passed to the `Api` constructor.                                                                                          |
-| `method?: 'GET' \| 'POST' \| 'PUT' \| 'PATCH' \| 'DELETE'`                                                     | HTTP method for the request. Defaults to `GET` if not provided.                                                                                                                                      |
-| `headers?: { [key: string]: string }`                                                                          | An object of key-value headers for the request.                                                                                                                                                      |
-| `body?: object \| string \| Blob \| BufferSource \| FormData \| URLSearchParams \| ReadableStream<Uint8Array>` | HTTP request body. If a plain JS object is passed, the `Content-Type: 'application/json'` header will automatically be set.                                                                          |
-| `responseType?: 'json' \| 'text' \| 'blob'`                                                                    | Expected response body format. If provided, the response body will be parsed to the provided format. If not passed, the response body type will be inferred from the `Content-Type` response header. |
-| `extraKey?: string`                                                                                            | An additional key to be serialized into the caching key.                                                                                                                                             |
+| Field                                                                                                          | Description                                                                                                                                                                                                                                                 |
+| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url: string`                                                                                                  | URL path for the request. This will be appended to the `baseUrl` which was passed to the `Api` constructor.                                                                                                                                                 |
+| `method?: 'GET' \| 'POST' \| 'PUT' \| 'PATCH' \| 'DELETE'`                                                     | HTTP method for the request. Defaults to `GET` if not provided.                                                                                                                                                                                             |
+| `headers?: { [key: string]: string }`                                                                          | An object of key-value headers for the request.                                                                                                                                                                                                             |
+| `body?: object \| string \| Blob \| BufferSource \| FormData \| URLSearchParams \| ReadableStream<Uint8Array>` | HTTP request body. If a plain JS object is passed, the `Content-Type: 'application/json'` header will automatically be set.                                                                                                                                 |
+| `responseType?: 'json' \| 'text' \| 'blob'`                                                                    | Expected response body format. If provided, the response body will be parsed to the provided format. If not passed, the response body type will be inferred from the `Content-Type` response header.                                                        |
+| `successCodes?: number[]`                                                                                      | An array of status codes which determine if the request was successful. If the response is _not_ one of these status codes, an `ApiError` will be thrown. When this is not set, any status code in the `200` range (200-299) will be considered successful. |
+| `extraKey?: string`                                                                                            | An additional key to be serialized into the caching key.                                                                                                                                                                                                    |
 
 `opts` fields:
 

--- a/src/api/errors.tsx
+++ b/src/api/errors.tsx
@@ -6,7 +6,7 @@ import {ApiResponseType, ResponseBody} from './typings'
 export class ApiCacheMissError extends Error {}
 
 /**
- * Thrown if a non-200 status response is received
+ * Thrown if a response is received with an incorrect status code.
  */
 export class ApiError<
   T extends ResponseBody | null = ResponseBody

--- a/src/api/errors.tsx
+++ b/src/api/errors.tsx
@@ -8,7 +8,9 @@ export class ApiCacheMissError extends Error {}
 /**
  * Thrown if a non-200 status response is received
  */
-export class ApiError<T extends ResponseBody | null> extends Error {
+export class ApiError<
+  T extends ResponseBody | null = ResponseBody
+> extends Error {
   public status: number
 
   public responseBody: T

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -114,6 +114,37 @@ describe('errors', () => {
     expect(onError).not.toBeCalled()
   })
 
+  it('throws an error if it doesnt match the specified success types', async () => {
+    const requestParams: ApiRequestParams = {
+      method: 'GET',
+      url: '/endpoint',
+      successCodes: [400, 401]
+    }
+    const errorJson = {test: 'error'}
+    fetchMock.mockResponseOnce(JSON.stringify(errorJson), {
+      headers: {'content-type': 'application/json'},
+      status: 400
+    })
+
+    expect(await api.request(requestParams)).toEqual({test: 'error'})
+
+    fetchMock.mockResponseOnce(JSON.stringify(errorJson), {
+      headers: {'content-type': 'application/json'},
+      status: 401
+    })
+
+    expect(await api.request(requestParams)).toEqual({test: 'error'})
+
+    fetchMock.mockResponseOnce(JSON.stringify({success: true}), {
+      headers: {'content-type': 'application/json'},
+      status: 200
+    })
+
+    await expect(api.request(requestParams)).rejects.toEqual(
+      new ApiError(200, {success: true})
+    )
+  })
+
   it('parses api error response json', async () => {
     const errorJson = '{"test_error": "bad-error"}'
     fetchMock.mockResponseOnce(JSON.stringify(errorJson), {

--- a/src/api/lib.spec.tsx
+++ b/src/api/lib.spec.tsx
@@ -136,6 +136,48 @@ describe('getParamsId', () => {
     )
   })
 
+  it('serializes success codes', () => {
+    for (const successCodes of [null, undefined]) {
+      const requestParams: ApiRequestParams = {
+        url: '/endpoint'
+      }
+
+      expect(getParamsId(requestParams)).toEqual(
+        getParamsId({
+          ...requestParams,
+          successCodes
+        })
+      )
+    }
+
+    const requestParams: ApiRequestParams = {
+      url: '/endpoint',
+      successCodes: [200, 201]
+    }
+
+    for (const successCodes of [[], [200], [201], [200, 201, 202]]) {
+      expect(getParamsId(requestParams)).not.toEqual(
+        getParamsId({
+          ...requestParams,
+          successCodes
+        })
+      )
+    }
+
+    for (const successCodes of [
+      [200, 201],
+      [201, 200],
+      [200, null, 201, null]
+    ]) {
+      expect(getParamsId(requestParams)).toEqual(
+        getParamsId({
+          ...requestParams,
+          successCodes
+        })
+      )
+    }
+  })
+
   it('serializes an extra key', () => {
     const requestParams: ApiRequestParams = {
       method: 'GET',

--- a/src/api/lib.tsx
+++ b/src/api/lib.tsx
@@ -16,7 +16,8 @@ export function getParamsId(
     params.url,
     params.responseType || '',
     serializeHeaders(params.headers),
-    params.extraKey
+    params.extraKey,
+    serializeSuccessCodes(params.successCodes)
   ])
 }
 
@@ -36,6 +37,24 @@ function serializeHeaders(paramHeaders?: ApiHeaders): string {
   headerPairs.sort()
 
   return headerPairs.join('')
+}
+
+function serializeSuccessCodes(successCodes?: number[]): string {
+  if (!successCodes) {
+    return ''
+  }
+
+  const serializedCodes = uniqueCodes(
+    successCodes.filter((code) => typeof code === 'number')
+  )
+
+  serializedCodes.sort()
+
+  return JSON.stringify(serializedCodes)
+}
+
+function uniqueCodes(codes: number[]): number[] {
+  return codes.filter((value, index, self) => self.indexOf(value) === index)
 }
 
 /**

--- a/src/api/request-fetcher/index.spec.tsx
+++ b/src/api/request-fetcher/index.spec.tsx
@@ -20,7 +20,7 @@ it('does not parse the response body if it cant determine the response type', as
       url: 'http://test.com/endpoint',
       method: 'GET'
     })
-  ).toEqual({responseBody: null, responseType: null})
+  ).toEqual({status: 200, body: null, bodyType: null})
 
   // unknown content type
   fetchMock.mockResponseOnce(JSON.stringify({num: 12345}), {
@@ -31,7 +31,7 @@ it('does not parse the response body if it cant determine the response type', as
       url: 'http://test.com/endpoint',
       method: 'GET'
     })
-  ).toEqual({responseBody: null, responseType: null})
+  ).toEqual({status: 200, body: null, bodyType: null})
 })
 
 it('throws a TypeError if an invalid responseBody is passed', async () => {

--- a/src/api/request-fetcher/index.tsx
+++ b/src/api/request-fetcher/index.tsx
@@ -27,9 +27,7 @@ export class ApiRequestFetcher implements RequestFetcher {
       params
     )
 
-    if (!response.ok) {
-      throw new ApiError(response.status, responseBody, responseType)
-    }
+    this.maybeThrowApiError(params, response, responseBody, responseType)
 
     return {responseBody, responseType}
   }
@@ -109,5 +107,24 @@ export class ApiRequestFetcher implements RequestFetcher {
     }
 
     return null
+  }
+
+  /**
+   * Throws `ApiError` if the response status does not match a passed success code.
+   * If no success codes are passed and the fetch response is not 'ok', throws `ApiError`
+   */
+  private maybeThrowApiError(
+    params: RequestFetcherParams,
+    response: Response,
+    responseBody: ResponseBody | null,
+    responseType: ApiResponseType | null
+  ): void {
+    if (Array.isArray(params.successCodes)) {
+      if (params.successCodes.every((code) => response.status !== code)) {
+        throw new ApiError(response.status, responseBody, responseType)
+      }
+    } else if (!response.ok) {
+      throw new ApiError(response.status, responseBody, responseType)
+    }
   }
 }

--- a/src/api/request-manager/index.tsx
+++ b/src/api/request-manager/index.tsx
@@ -210,7 +210,8 @@ export class ApiRequestManager {
         url: `${this.baseUrl}${params.url}`,
         body,
         headers,
-        responseType: params.responseType
+        responseType: params.responseType,
+        successCodes: params.successCodes
       })
 
       const responseBody =

--- a/src/api/request-manager/index.tsx
+++ b/src/api/request-manager/index.tsx
@@ -14,6 +14,7 @@ import {
   ApiSerializeRequestJson,
   RequestBody,
   RequestFetcher,
+  RequestFetcherResponse,
   ResponseBody
 } from '../typings'
 
@@ -176,37 +177,12 @@ export class ApiRequestManager {
     params: ApiRequestParams,
     options: ApiRequestOptions
   ): Promise<ResponseBody | null> => {
-    const {method = DEFAULT_REQUEST_METHOD} = params
     const {fetchPolicy = this.defaultFetchPolicy} = options
     try {
-      let headers = new Headers(this.defaultHeaders)
-
-      if (params.headers) {
-        headers = applyHeaders(headers, params.headers)
-      }
-
-      let body: BodyInit | undefined
-
-      if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
-        const paramBody = (params as {body: RequestBody}).body
-
-        if (
-          paramBody &&
-          ![Blob, FormData, URLSearchParams, ReadableStream].some(
-            (bodyType) => paramBody instanceof bodyType
-          ) &&
-          typeof paramBody !== 'string'
-        ) {
-          // prepare JSON body and add header
-          body = JSON.stringify(this.serializeRequestJson(paramBody as object))
-          headers.set('Content-Type', 'application/json')
-        } else {
-          body = paramBody as BodyInit
-        }
-      }
+      const {body, headers} = this.getRequestHeadersAndBody(params)
 
       const response = await this.requestFetcher.getResponse({
-        method,
+        method: params.method || DEFAULT_REQUEST_METHOD,
         url: `${this.baseUrl}${params.url}`,
         body,
         headers,
@@ -214,10 +190,17 @@ export class ApiRequestManager {
         successCodes: params.successCodes
       })
 
-      const responseBody =
-        response.responseType === 'json'
-          ? this.parseResponseJson(response.responseBody as object)
-          : response.responseBody
+      const parsedResponse: RequestFetcherResponse = {
+        ...response,
+        body:
+          response.bodyType === 'json'
+            ? this.parseResponseJson(response.body as object, params)
+            : response.body
+      }
+
+      this.maybeThrowApiError(params, parsedResponse)
+
+      const {body: responseBody} = parsedResponse
 
       if (fetchPolicy !== 'no-cache') {
         this.emitter.emit(RECEIVED_RESPONSE_BODY_EVENT, params, responseBody)
@@ -225,13 +208,68 @@ export class ApiRequestManager {
 
       return responseBody
     } catch (error) {
-      /* istanbul ignore next */
-      if (error instanceof ApiError && error.responseType === 'json') {
-        error.responseBody = this.parseResponseJson(error.responseBody)
-      }
-
       this.emitter.emit(ERROR_EVENT, error)
       throw error
+    }
+  }
+
+  /**
+   * Modifies request headers and body to use for the request.
+   * - Headers are merged with any defined default headers.
+   * - For JSON request bodies, it is serialized to a string and
+   *   sets the appropriate 'Content-Type' header.
+   */
+  private getRequestHeadersAndBody(
+    params: ApiRequestParams
+  ): {headers: Headers; body: BodyInit | undefined} {
+    let headers = new Headers(this.defaultHeaders)
+
+    if (params.headers) {
+      headers = applyHeaders(headers, params.headers)
+    }
+
+    let body: BodyInit | undefined
+
+    if (
+      params.method &&
+      ['POST', 'PATCH', 'PUT', 'DELETE'].includes(params.method)
+    ) {
+      const paramBody = (params as {body: RequestBody}).body
+
+      if (
+        paramBody &&
+        ![Blob, FormData, URLSearchParams, ReadableStream].some(
+          (bodyType) => paramBody instanceof bodyType
+        ) &&
+        typeof paramBody !== 'string'
+      ) {
+        // prepare JSON body and add header
+        body = JSON.stringify(
+          this.serializeRequestJson(paramBody as object, params)
+        )
+        headers.set('Content-Type', 'application/json')
+      } else {
+        body = paramBody as BodyInit
+      }
+    }
+
+    return {headers, body}
+  }
+
+  /**
+   * Throws `ApiError` if the response status does not match a passed success code.
+   * If no success codes are passed and the fetch response is not 'ok', throws `ApiError`
+   */
+  private maybeThrowApiError(
+    params: ApiRequestParams,
+    {status, body: responseBody, bodyType: responseType}: RequestFetcherResponse
+  ): void {
+    if (Array.isArray(params.successCodes)) {
+      if (params.successCodes.every((code) => status !== code)) {
+        throw new ApiError(status, responseBody, responseType)
+      }
+    } else if (status < 200 || status > 299) {
+      throw new ApiError(status, responseBody, responseType)
     }
   }
 }

--- a/src/api/typings.tsx
+++ b/src/api/typings.tsx
@@ -14,6 +14,7 @@ interface ApiCommonRequestParams<TMethod extends ApiRequestMethod> {
   method?: TMethod
   headers?: ApiHeaders
   responseType?: ApiResponseType
+  successCodes?: number[]
   extraKey?: string
 }
 
@@ -92,6 +93,7 @@ export interface RequestFetcherParams {
   body?: BodyInit
   headers?: Headers
   responseType?: ApiResponseType
+  successCodes?: number[]
 }
 
 export interface RequestFetcher {

--- a/src/api/typings.tsx
+++ b/src/api/typings.tsx
@@ -39,9 +39,15 @@ export type ApiRequestParams<
   ? ApiMutationRequestParams<TMethod, TResponseBody>
   : never
 
-export type ApiSerializeRequestJson = (body: object) => object
+export type ApiSerializeRequestJson = (
+  body: object,
+  requestParams: ApiRequestParams
+) => object
 
-export type ApiParseResponseJson = (body: object) => object
+export type ApiParseResponseJson = (
+  body: object,
+  requestParams: ApiRequestParams
+) => object
 
 export type ApiRequestFetchPolicy =
   /**
@@ -97,10 +103,11 @@ export interface RequestFetcherParams {
 }
 
 export interface RequestFetcher {
-  getResponse(
-    params: RequestFetcherParams
-  ): Promise<{
-    responseBody: ResponseBody | null
-    responseType: ApiResponseType | null
-  }>
+  getResponse(params: RequestFetcherParams): Promise<RequestFetcherResponse>
+}
+
+export interface RequestFetcherResponse {
+  body: ResponseBody | null
+  bodyType: ApiResponseType | null
+  status: number
 }

--- a/src/endpoints/index.tsx
+++ b/src/endpoints/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-dupe-class-members */
 
 import {
-  ApiHeaders,
   ApiRequestMethod,
   ApiRequestParams,
   RequestBody,
@@ -10,11 +9,10 @@ import {
 
 export type ApiQueryParams = Record<string, string | number | boolean>
 
-export interface EndpointCreateRequestInit {
+export interface EndpointCreateRequestInit
+  extends Omit<ApiRequestParams, 'url' | 'method'> {
   query?: ApiQueryParams
-  headers?: ApiHeaders
   body?: RequestBody
-  extraKey?: string
 }
 
 export type ApiParam = string | number
@@ -157,16 +155,16 @@ export class HttpEndpoints {
   ): ApiRequestParams<TMethod, TResponseBody> {
     let url = this.buildPath(path)
 
-    if (requestInit.query) {
-      url += `?${this._serializeQuery(requestInit.query)}`
+    const {query, ...restRequestInit} = requestInit
+
+    if (query) {
+      url += `?${this._serializeQuery(query)}`
     }
 
     return {
       method,
       url,
-      headers: requestInit.headers,
-      body: requestInit.body,
-      extraKey: requestInit.extraKey
+      ...restRequestInit
     } as ApiRequestParams<TMethod, TResponseBody>
   }
 }


### PR DESCRIPTION
* Allow `successCodes` to be set when making an API request. This overrides the default `200`-level success code default. Similar to [`axios`](https://github.com/axios/axios)'s `validateStatus` method.
* Pass `requestParams` as second argument to `serializeRequestJson` and `parseResponseJson`
* Refactor parts of the code in an attempt to make things more clear

Resolves #6