### PR TITLE
Export use api query types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fairlight",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cache",
     "fetch"
   ],
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/react/use-api-query/index.tsx
+++ b/src/react/use-api-query/index.tsx
@@ -19,6 +19,8 @@ import {
   UseApiQuerySetData
 } from './typings'
 
+export * from './typings'
+
 /**
  * API hook to run an api `GET` request, returning a `Loadable`
  * instance of the response data


### PR DESCRIPTION
* Fix regression in the exported typescript types
* Bump version to `v0.6.2`
