### PR TITLE
Add useApiQuery#useErrorBoundary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ Standard request params. See [Api#request()](#requestparams-object-opts-object) 
 | `fetchPolicy?: 'no-cache' \| 'cache-first' \| 'fetch-first' \| 'cache-only' \| 'cache-and-fetch'` | The fetch policy to use for the request. This is passed directly to `api.request` under the hood. By default, this is set to `cache-and-fetch` but can be overridden via `ApiProvider`                                                                                     |
 | `deduplicate?: boolean`                                                                           | If `true`, will deduplicate equivalent requests, ensuring that it only runs once concurrently and returns an equal promise for each parallel call. This is `true` by default for `GET` requests, and `false` by default for `POST`, `PUT`, `PATCH`, and `DELETE` requests. |
 | `dontReinitialize?: boolean`                                                                      | If true, will keep `data` from previous requests until new data is received (ie. it won't reinitialize to `null`).                                                                                                                                                         |
+| `useErrorBoundary?: boolean`                                                                      | If true, will throw on error that will bubble up to an error boundary. This is `false` by default, but can be overridden globally via `ApiProvider`.                                                                                                                       |
 
 Returns `[queryData, queryActions]`:
 
@@ -734,8 +735,10 @@ const api = new Api({baseUrl: 'http://your-api.com/api'})
 const App = () => (
   <ApiProvider
     api={api}
-    defaultFetchPolicies={{
-      useApiQuery: 'cache-and-fetch'
+    defaults={{
+      useApiQuery: {
+        fetchPolicy: 'cache-and-fetch'
+      }
     }}
   >
     {/* render app here */}
@@ -749,16 +752,17 @@ const App = () => (
 
 `props`:
 
-| Field                          | Description                                                                      |
-| ------------------------------ | -------------------------------------------------------------------------------- |
-| `api: Api`                     | `Api` instance to provide to your app.                                           |
-| `defaultFetchPolicies: object` | Sets the default `fetchPolicy` to use for hooks. See below for possible options. |
+| Field              | Description                                                         |
+| ------------------ | ------------------------------------------------------------------- |
+| `api: Api`         | `Api` instance to provide to your app.                              |
+| `defaults: object` | Sets the defaults to use for hooks. See below for possible options. |
 
-`defaultFetchPolicies` fields:
+`defaults` fields:
 
-| Field                                                                                            | Description                                                                                                     |
-| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `useApiQuery: 'no-cache' \| 'cache-first' \| 'fetch-first' \| 'cache-only' \| 'cache-and-fetch'` | The `fetchPolicy` to use by default for the `useApiQuery` hook. Defaults to `cache-and-fetch` if not specified. |
+| Field                                                                                                         | Description                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `useApiQuery.fetchPolicy?: 'no-cache' \| 'cache-first' \| 'fetch-first' \| 'cache-only' \| 'cache-and-fetch'` | The `fetchPolicy` to use by default for the `useApiQuery` hook. Defaults to `cache-and-fetch` if not specified. |
+| `useApiQuery.useErrorBoundary?: boolean`                                                                      | The `useErrorBoundary` to use by default for the `useApiQuery` hook. Defaults to `true` if not specified.       |
 
 </details>
 

--- a/src/api/errors.tsx
+++ b/src/api/errors.tsx
@@ -1,4 +1,4 @@
-import {ApiResponseType, ResponseBody} from './typings'
+import {ApiRequestMethod, ApiResponseType, ResponseBody} from './typings'
 
 /**
  * Thrown if a value doesn't exist in the cache
@@ -11,18 +11,26 @@ export class ApiCacheMissError extends Error {}
 export class ApiError<
   T extends ResponseBody | null = ResponseBody
 > extends Error {
+  public method: ApiRequestMethod
+
+  public url: string
+
   public status: number
 
-  public responseBody: T
+  public responseBody: T | null
 
   public responseType?: ApiResponseType | null
 
   constructor(
+    method: ApiRequestMethod,
+    url: string,
     status: number,
     responseBody: T,
     responseType?: ApiResponseType | null
   ) {
-    super(`API Error: ${status}`)
+    super(`API Error: \`${method} ${url}\` failed with status ${status}`)
+    this.method = method
+    this.url = url
     this.responseBody = responseBody
     this.status = status
     this.responseType = responseType

--- a/src/api/request-manager/index.tsx
+++ b/src/api/request-manager/index.tsx
@@ -262,14 +262,26 @@ export class ApiRequestManager {
    */
   private maybeThrowApiError(
     params: ApiRequestParams,
-    {status, body: responseBody, bodyType: responseType}: RequestFetcherResponse
+    {status, body, bodyType}: RequestFetcherResponse
   ): void {
     if (Array.isArray(params.successCodes)) {
       if (params.successCodes.every((code) => status !== code)) {
-        throw new ApiError(status, responseBody, responseType)
+        throw new ApiError(
+          params.method ?? DEFAULT_REQUEST_METHOD,
+          params.url,
+          status,
+          body,
+          bodyType
+        )
       }
     } else if (status < 200 || status > 299) {
-      throw new ApiError(status, responseBody, responseType)
+      throw new ApiError(
+        params.method ?? DEFAULT_REQUEST_METHOD,
+        params.url,
+        status,
+        body,
+        bodyType
+      )
     }
   }
 }

--- a/src/react/context.spec.tsx
+++ b/src/react/context.spec.tsx
@@ -1,0 +1,18 @@
+import React, {useContext} from 'react'
+
+import {renderHook} from '@testing-library/react-hooks'
+
+import {Api} from '../api'
+import {ApiContext, ApiProvider} from './context'
+
+describe('ApiProvider', () => {
+  it('defaults to a basic api', () => {
+    const {result} = renderHook(() => useContext(ApiContext), {
+      wrapper: function WithProvider({children}) {
+        return <ApiProvider>{children}</ApiProvider>
+      }
+    })
+
+    expect(result.current.api).toBeInstanceOf(Api)
+  })
+})

--- a/src/react/context.tsx
+++ b/src/react/context.tsx
@@ -4,34 +4,49 @@ import {Api} from '../api'
 import {ApiRequestFetchPolicy} from '../api/typings'
 
 const DEFAULT_QUERY_FETCH_POLICY = 'cache-and-fetch'
+const DEFAULT_QUERY_USE_ERROR_BOUNDARY = false
 
 interface ApiContext {
   api: Api
-  defaultFetchPolicies: ApiProviderDefaultFetchPolicies
+  defaults: ApiProviderDefaults
 }
 
-interface ApiProviderDefaultFetchPolicies {
-  useApiQuery: ApiRequestFetchPolicy
+interface ApiProviderDefaults {
+  useApiQuery: UseApiQueryDefaults
 }
 
-export const ApiContext = createContext<ApiContext>({
-  api: new Api(),
-  defaultFetchPolicies: {
-    useApiQuery: DEFAULT_QUERY_FETCH_POLICY
+interface UseApiQueryDefaults {
+  fetchPolicy: ApiRequestFetchPolicy
+  useErrorBoundary: boolean
+}
+
+const defaultApi = new Api()
+
+const DEFAULT_API_CONTEXT: ApiContext = {
+  api: defaultApi,
+  defaults: {
+    useApiQuery: {
+      fetchPolicy: DEFAULT_QUERY_FETCH_POLICY,
+      useErrorBoundary: DEFAULT_QUERY_USE_ERROR_BOUNDARY
+    }
   }
-})
+}
+
+export const ApiContext = createContext<ApiContext>(DEFAULT_API_CONTEXT)
 
 export interface ApiProviderProps {
   /**
    * The API instance to use
    */
-  api: Api
+  api?: Api
 
   /**
    * Sets the default `fetchPolicy` which is used by `useApiQuery`
    * if no `fetchPolicy` is provided to the hook.
    */
-  defaultFetchPolicies?: Partial<ApiProviderDefaultFetchPolicies>
+  defaults?: {
+    useApiQuery?: Partial<UseApiQueryDefaults>
+  }
 }
 
 export const ApiProvider: React.FC<ApiProviderProps> = function ApiProvider(
@@ -40,11 +55,16 @@ export const ApiProvider: React.FC<ApiProviderProps> = function ApiProvider(
   return (
     <ApiContext.Provider
       value={{
-        api: props.api,
-        defaultFetchPolicies: {
-          useApiQuery:
-            props.defaultFetchPolicies?.useApiQuery ||
-            DEFAULT_QUERY_FETCH_POLICY
+        api: props.api || DEFAULT_API_CONTEXT.api,
+        defaults: {
+          useApiQuery: {
+            fetchPolicy:
+              props.defaults?.useApiQuery?.fetchPolicy ||
+              DEFAULT_API_CONTEXT.defaults.useApiQuery.fetchPolicy,
+            useErrorBoundary:
+              props.defaults?.useApiQuery?.useErrorBoundary ||
+              DEFAULT_API_CONTEXT.defaults.useApiQuery.useErrorBoundary
+          }
         }
       }}
     >

--- a/src/react/use-api-query/index.tsx
+++ b/src/react/use-api-query/index.tsx
@@ -31,10 +31,16 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
 ): [UseApiQueryData<TResponseBody>, UseApiQueryActions<TResponseBody>] {
   const {
     api,
-    defaultFetchPolicies: {useApiQuery: defaultFetchPolicy}
+    defaults: {
+      useApiQuery: {
+        fetchPolicy: defaultFetchPolicy,
+        useErrorBoundary: defaultUseErrorBoundary
+      }
+    }
   } = useContext(ApiContext)
 
-  const fetchPolicy = opts.fetchPolicy || defaultFetchPolicy
+  const fetchPolicy = opts.fetchPolicy ?? defaultFetchPolicy
+  const useErrorBoundary = opts.useErrorBoundary ?? defaultUseErrorBoundary
 
   const [state, dispatch] = useReducer(useApiQueryReducer, INITIAL_STATE)
 
@@ -136,6 +142,13 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
       error: derivedState.error
     }
   }, [derivedState.loading, derivedState.data, derivedState.error])
+
+  /**
+   * Optionally throw the error to handle in error boundary
+   */
+  if (returnData.error && useErrorBoundary) {
+    throw returnData.error
+  }
 
   const handleSetData: UseApiQuerySetData<TResponseBody> = (data) => {
     if (fetchPolicy === 'no-cache' || !params) {

--- a/src/react/use-api-query/typings.tsx
+++ b/src/react/use-api-query/typings.tsx
@@ -75,6 +75,14 @@ export interface UseApiQueryOptions {
    * until new data is received.
    */
   dontReinitialize?: boolean
+
+  /**
+   * If `true`, will `throw` in the case of an error, which can then
+   * be handled in an error boundary.
+   *
+   * Defaults to `false`, unless overridden via `ApiProvider#defaults`
+   */
+  useErrorBoundary?: boolean
 }
 
 export type FalsyValue = '' | 0 | false | undefined | null


### PR DESCRIPTION
* Add `useErrorBoundary` flag to `useApiQuery#opts`, which will cause an error to be thrown and handled in an error boundary.
* Update `ApiProvider#defaults` API structure and add `useApiQuery#useErrorBoundary` option